### PR TITLE
Individual snapshot progress indicators and bouncing ball spinners

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -645,7 +645,7 @@ fn render<'a>(
 }
 
 /// Util ///////////////////////////////////////////////////////////////////////
-pub fn new_style(template: &str) -> ProgressStyle {
+fn new_style(template: &str) -> ProgressStyle {
     let frames = &[
         "(●    )",
         "( ●   )",
@@ -662,7 +662,7 @@ pub fn new_style(template: &str) -> ProgressStyle {
 
 const PB_TICK_INTERVAL: Duration = Duration::from_millis(100);
 
-pub fn new_pb(template: &str) -> ProgressBar {
+fn new_pb(template: &str) -> ProgressBar {
     let pb = ProgressBar::new_spinner().with_style(new_style(template));
     pb.enable_steady_tick(PB_TICK_INTERVAL);
     pb
@@ -670,7 +670,7 @@ pub fn new_pb(template: &str) -> ProgressBar {
 
 // This is necessary to avoid some weird redraws that happen
 // when enabling the tick thread before adding to the MultiProgress.
-pub fn mpb_add(mpb: &MultiProgress, template: &str) -> ProgressBar {
+fn mpb_add(mpb: &MultiProgress, template: &str) -> ProgressBar {
     let pb =
         mpb.add(ProgressBar::new_spinner().with_style(new_style(template)));
     pb.enable_steady_tick(PB_TICK_INTERVAL);

--- a/src/main.rs
+++ b/src/main.rs
@@ -287,7 +287,7 @@ fn sync_snapshots(
             .map(|snapshot_id| cache.get_snapshot_group(snapshot_id))
             .collect::<Result<HashSet<u64>, rusqlite::Error>>()?;
         if groups_to_delete.len() > 0 {
-            eprintln!("Need to delete {} groups", groups_to_delete.len());
+            eprintln!("Need to delete {} group(s)", groups_to_delete.len());
             let pb = new_pb("{wide_bar} [{pos}/{len}] {spinner}");
             pb.set_length(groups_to_delete.len() as u64);
             for group in groups_to_delete {

--- a/src/main.rs
+++ b/src/main.rs
@@ -668,6 +668,8 @@ pub fn new_pb(template: &str) -> ProgressBar {
     pb
 }
 
+// This is necessary to avoid some weird redraws that happen
+// when enabling the tick thread before adding to the MultiProgress.
 pub fn mpb_add(mpb: &MultiProgress, template: &str) -> ProgressBar {
     let pb =
         mpb.add(ProgressBar::new_spinner().with_style(new_style(template)));

--- a/src/main.rs
+++ b/src/main.rs
@@ -699,9 +699,21 @@ impl Speed {
 }
 
 pub fn new_pb(style: &str) -> ProgressBar {
-    let pb = ProgressBar::new_spinner()
-        .with_style(ProgressStyle::with_template(style).unwrap());
-    pb.enable_steady_tick(Duration::from_millis(500));
+    let frames = &[
+        "(●    )",
+        "( ●   )",
+        "(  ●  )",
+        "(   ● )",
+        "(   ● )",
+        "(  ●  )",
+        "( ●   )",
+        "(●    )",
+        "(●    )",
+    ];
+    let style = ProgressStyle::with_template(style).unwrap()
+        .tick_strings(frames);
+    let pb = ProgressBar::new_spinner().with_style(style);
+    pb.enable_steady_tick(Duration::from_millis(100));
     pb
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -660,15 +660,18 @@ pub fn new_style(template: &str) -> ProgressStyle {
     ProgressStyle::with_template(template).unwrap().tick_strings(frames)
 }
 
+const PB_TICK_INTERVAL: Duration = Duration::from_millis(100);
+
 pub fn new_pb(template: &str) -> ProgressBar {
     let pb = ProgressBar::new_spinner().with_style(new_style(template));
-    pb.enable_steady_tick(Duration::from_millis(100));
+    pb.enable_steady_tick(PB_TICK_INTERVAL);
     pb
 }
 
 pub fn mpb_add(mpb: &MultiProgress, template: &str) -> ProgressBar {
-    let pb = mpb.add(ProgressBar::new_spinner().with_style(new_style(template)));
-    pb.enable_steady_tick(Duration::from_millis(100));
+    let pb =
+        mpb.add(ProgressBar::new_spinner().with_style(new_style(template)));
+    pb.enable_steady_tick(PB_TICK_INTERVAL);
     pb
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -427,8 +427,10 @@ fn fetching_thread_body(
     trace!("started");
     while let Some(snapshot) = missing_queue.pop() {
         let short_id = snapshot_short_id(&snapshot);
-        let pb = mpb.add(new_pb("   {spinner} fetching {prefix}: starting up"));
-        pb.set_prefix(short_id.clone());
+        let pb = mpb.add(
+            new_pb("   {spinner} fetching {prefix}: starting up")
+                .with_prefix(short_id.clone())
+        );
         let mut filetree = FileTree::new();
         let files = restic.ls(&snapshot)?;
         trace!("started fetching snapshot ({short_id})");

--- a/src/restic.rs
+++ b/src/restic.rs
@@ -240,7 +240,7 @@ impl<T> Iter<T> {
     }
 
     fn finish(&mut self) {
-        if ! self.finished {
+        if !self.finished {
             info!("finished pid {}", self.child.id());
         }
     }
@@ -257,7 +257,10 @@ impl<T: DeserializeOwned> Iterator for Iter<T> {
                 (value, line.len())
             };
             Some(match r_value {
-                Err(kind) => { self.finish(); self.read_stderr(kind) }
+                Err(kind) => {
+                    self.finish();
+                    self.read_stderr(kind)
+                }
                 Ok(value) => Ok(value),
             })
         } else {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -453,7 +453,7 @@ impl WidgetRef for App {
     fn render_ref(&self, area: Rect, buf: &mut Buffer) {
         let (header_rect, list_rect, footer_rect) = compute_layout(area);
         {
-            // Heading
+            // Header
             let mut string = "--- ".to_string();
             string.push_str(
                 shorten_to(
@@ -461,7 +461,8 @@ impl WidgetRef for App {
                         None => "#",
                         Some(path) => path.as_str(),
                     },
-                    header_rect.width as usize - string.len(),
+                    max(0, header_rect.width as isize - string.len() as isize)
+                        as usize,
                 )
                 .as_ref(),
             );


### PR DESCRIPTION
- Each fetching thread now displays its own progress bar with a fetched file count
- Opted not to get the total file count beforehand because `restic stats` takes a long time
- Bouncing ball spinners

Closes #16 