### PR TITLE
Shard entries table by snapshot

### DIFF
--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -49,6 +49,7 @@ impl Cache {
 
     /// This is not very efficient, it does one query per path component.
     /// Mainly used for testing convenience.
+    #[cfg(any(test, feature = "bench"))]
     pub fn get_path_id_by_path(
         &self,
         path: &Utf8Path,
@@ -115,6 +116,7 @@ impl Cache {
                 [hash.as_ref()],
                 |row| row.get::<usize, u64>(0),
             )?;
+
             let mut paths_stmt = tx.prepare(
                 "INSERT INTO paths (parent_id, component)
                  VALUES (?, ?)
@@ -123,6 +125,7 @@ impl Cache {
             let mut paths_query = tx.prepare(
                 "SELECT id FROM paths WHERE parent_id = ? AND component = ?",
             )?;
+
             let mut entries_stmt = tx.prepare(
                 "INSERT INTO entries (snapshot_id, path_id, size, is_dir)
                  VALUES (?, ?, ?, ?)",

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -108,7 +108,8 @@ impl Cache {
         &mut self,
         hash: impl AsRef<str>,
         tree: SizeTree,
-    ) -> Result<(), rusqlite::Error> {
+    ) -> Result<usize, rusqlite::Error> {
+        let mut file_count = 0;
         let tx = self.conn.transaction()?;
         {
             let snapshot_id = tx.query_row(
@@ -148,11 +149,13 @@ impl Cache {
                         size,
                         is_dir
                     ])?;
+                    file_count += 1;
                     Ok::<PathId, rusqlite::Error>(path_id)
                 },
             )?;
         }
-        tx.commit()
+        tx.commit()?;
+        Ok(file_count)
     }
 
     pub fn delete_snapshot(

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -61,7 +61,7 @@ impl Cache {
             path_id = self
                 .conn
                 .query_row(
-                    "SELECT id FROM paths
+                    "SELECT id FROM paths \
                      WHERE parent_id = ? AND component = ?",
                     params![o_path_id_to_raw_u64(path_id), component],
                     |row| row.get(0).map(PathId),
@@ -108,14 +108,14 @@ impl Cache {
                 .intersperse(String::from(" UNION ALL "))
                 .collect::<String>();
         let mut stmt = self.conn.prepare(&format!(
-            "WITH rich_entries AS ({cte_stmt_string})
-             SELECT
-                 path_id,
-                 component,
-                 max(size) as size,
-                 max(is_dir) as is_dir
-             FROM rich_entries
-             GROUP BY path_id
+            "WITH rich_entries AS ({cte_stmt_string}) \
+             SELECT \
+                 path_id, \
+                 component, \
+                 max(size) as size, \
+                 max(is_dir) as is_dir \
+             FROM rich_entries \
+             GROUP BY path_id \
              ORDER BY size DESC",
         ))?;
         let rows = stmt.query_map([], aux)?;

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -137,7 +137,8 @@ impl Cache {
                     "CREATE TABLE \"{entries_table}\" (
                          path_id INTEGER PRIMARY KEY,
                          size INTEGER NOT NULL,
-                         is_dir INTEGER NOT NULL
+                         is_dir INTEGER NOT NULL,
+                         FOREIGN KEY (path_id) REFERENCES paths (id)
                      )"
                 ),
                 [],

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -27,11 +27,13 @@ pub enum OpenError {
 }
 
 impl Cache {
-    pub fn get_snapshots(&self) -> Result<Vec<Box<str>>, rusqlite::Error> {
-        self.conn
-            .prepare("SELECT hash FROM snapshots")?
-            .query_map([], |row| row.get("hash"))?
-            .collect()
+    pub fn get_snapshots(&self) -> Result<Vec<String>, rusqlite::Error> {
+        Ok(get_tables(&self.conn)?
+            .iter()
+            .filter_map(|name| {
+                name.strip_prefix("entries_").map(ToOwned::to_owned)
+            })
+            .collect())
     }
 
     pub fn get_parent_id(
@@ -82,25 +84,41 @@ impl Cache {
         let aux = |row: &Row| {
             Ok(Entry {
                 path_id: PathId(row.get("path_id")?),
-                parent_id: raw_u64_to_o_path_id(row.get("parent_id")?),
                 component: row.get("component")?,
                 size: row.get("size")?,
                 is_dir: row.get("is_dir")?,
             })
         };
-        let mut stmt = self.conn.prepare(
-            "SELECT
+        let raw_path_id = o_path_id_to_raw_u64(path_id);
+        let cte_stmt_string =
+            get_tables(&self.conn)?
+                .into_iter()
+                .filter(|name| name.starts_with("entries_"))
+                .map(|table| {
+                    format!(
+                        "SELECT \
+                             path_id, \
+                             component, \
+                             size, \
+                             is_dir \
+                         FROM \"{table}\" JOIN paths ON path_id = paths.id \
+                         WHERE parent_id = {raw_path_id}\n"
+                    )
+                })
+                .intersperse(String::from(" UNION ALL "))
+                .collect::<String>();
+        let mut stmt = self.conn.prepare(&format!(
+            "WITH rich_entries AS ({cte_stmt_string})
+             SELECT
                  path_id,
-                 parent_id,
                  component,
                  max(size) as size,
                  max(is_dir) as is_dir
-             FROM entries JOIN paths ON path_id = paths.id
-             WHERE parent_id = ?
+             FROM rich_entries
              GROUP BY path_id
              ORDER BY size DESC",
-        )?;
-        let rows = stmt.query_map([o_path_id_to_raw_u64(path_id)], aux)?;
+        ))?;
+        let rows = stmt.query_map([], aux)?;
         rows.collect()
     }
 
@@ -112,10 +130,17 @@ impl Cache {
         let mut file_count = 0;
         let tx = self.conn.transaction()?;
         {
-            let snapshot_id = tx.query_row(
-                "INSERT INTO snapshots (hash) VALUES (?) RETURNING (id)",
-                [hash.as_ref()],
-                |row| row.get::<usize, u64>(0),
+            let entries_table = format!("entries_{}", hash.as_ref());
+
+            tx.execute(
+                &format!(
+                    "CREATE TABLE \"{entries_table}\" (
+                         path_id INTEGER PRIMARY KEY,
+                         size INTEGER NOT NULL,
+                         is_dir INTEGER NOT NULL
+                     )"
+                ),
+                [],
             )?;
 
             let mut paths_stmt = tx.prepare(
@@ -127,10 +152,10 @@ impl Cache {
                 "SELECT id FROM paths WHERE parent_id = ? AND component = ?",
             )?;
 
-            let mut entries_stmt = tx.prepare(
-                "INSERT INTO entries (snapshot_id, path_id, size, is_dir)
-                 VALUES (?, ?, ?, ?)",
-            )?;
+            let mut entries_stmt = tx.prepare(&format!(
+                "INSERT INTO \"{entries_table}\" (path_id, size, is_dir) \
+                 VALUES (?, ?, ?)",
+            ))?;
 
             tree.0.traverse_with_context(
                 |id_stack, component, size, is_dir| {
@@ -143,12 +168,7 @@ impl Cache {
                         params![o_path_id_to_raw_u64(parent_id), component],
                         |row| row.get(0).map(PathId),
                     )?;
-                    entries_stmt.execute(params![
-                        snapshot_id,
-                        path_id.0,
-                        size,
-                        is_dir
-                    ])?;
+                    entries_stmt.execute(params![path_id.0, size, is_dir])?;
                     file_count += 1;
                     Ok::<PathId, rusqlite::Error>(path_id)
                 },
@@ -162,21 +182,11 @@ impl Cache {
         &mut self,
         hash: impl AsRef<str>,
     ) -> Result<(), rusqlite::Error> {
-        let hash = hash.as_ref();
-        let tx = self.conn.transaction()?;
-        if let Some(snapshot_id) = tx
-            .query_row(
-                "DELETE FROM snapshots WHERE hash = ? RETURNING (id)",
-                [hash],
-                |row| row.get::<usize, u64>(0),
-            )
-            .optional()?
-        {
-            tx.execute("DELETE FROM entries WHERE snapshot_id = ?", [
-                snapshot_id,
-            ])?;
-        }
-        tx.commit()
+        self.conn.execute(
+            &format!("DROP TABLE IF EXISTS \"entries_{}\"", hash.as_ref()),
+            [],
+        )?;
+        Ok(())
     }
 
     // Marks ////////////////////////////////////////////////
@@ -233,7 +243,6 @@ fn o_path_id_to_raw_u64(path_id: Option<PathId>) -> u64 {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Entry {
     pub path_id: PathId,
-    pub parent_id: Option<PathId>,
     pub component: String,
     pub size: usize,
     pub is_dir: bool,

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -90,23 +90,22 @@ impl Cache {
             })
         };
         let raw_path_id = o_path_id_to_raw_u64(path_id);
-        let cte_stmt_string =
-            get_tables(&self.conn)?
-                .into_iter()
-                .filter(|name| name.starts_with("entries_"))
-                .map(|table| {
-                    format!(
-                        "SELECT \
-                             path_id, \
-                             component, \
-                             size, \
-                             is_dir \
-                         FROM \"{table}\" JOIN paths ON path_id = paths.id \
-                         WHERE parent_id = {raw_path_id}\n"
-                    )
-                })
-                .intersperse(String::from(" UNION ALL "))
-                .collect::<String>();
+        let cte_stmt_string = get_tables(&self.conn)?
+            .into_iter()
+            .filter(|name| name.starts_with("entries_"))
+            .map(|table| {
+                format!(
+                    "SELECT \
+                         path_id, \
+                         component, \
+                         size, \
+                         is_dir \
+                     FROM \"{table}\" JOIN paths ON path_id = paths.id \
+                     WHERE parent_id = {raw_path_id}\n"
+                )
+            })
+            .intersperse(String::from(" UNION ALL "))
+            .collect::<String>();
         let mut stmt = self.conn.prepare(&format!(
             "WITH rich_entries AS ({cte_stmt_string}) \
              SELECT \

--- a/src/cache/sql/none_to_v1.sql
+++ b/src/cache/sql/none_to_v1.sql
@@ -4,12 +4,6 @@ CREATE TABLE metadata_integer (
 ) WITHOUT ROWID;
 INSERT INTO metadata_integer (key, value) VALUES ('version', 1);
 
-CREATE TABLE snapshots (
-    id INTEGER PRIMARY KEY,
-    hash TEXT UNIQUE NOT NULL
-);
-CREATE INDEX snapshots_hash ON snapshots (hash);
-
 CREATE TABLE paths (
     id INTEGER PRIMARY KEY,
     parent_id INTEGER NOT NULL,
@@ -17,15 +11,6 @@ CREATE TABLE paths (
 );
 CREATE UNIQUE INDEX paths_parent_component ON paths (parent_id, component);
 
-CREATE TABLE entries (
-    snapshot_id INTEGER NOT NULL,
-    path_id INTEGER NOT NULL,
-    size INTEGER NOT NULL,
-    is_dir INTEGER NOT NULL,
-    PRIMARY KEY (path_id, snapshot_id)
-) WITHOUT ROWID;
-CREATE INDEX entries_snapshot_id ON entries (snapshot_id); -- for deletion
+-- The entries tables are sharded per snapshot and created dynamically
 
-CREATE TABLE marks (
-    path TEXT PRIMARY KEY
-) WITHOUT ROWID;
+CREATE TABLE marks (path TEXT PRIMARY KEY) WITHOUT ROWID;

--- a/src/cache/sql/none_to_v1.sql
+++ b/src/cache/sql/none_to_v1.sql
@@ -1,7 +1,7 @@
 CREATE TABLE metadata_integer (
     key TEXT PRIMARY KEY,
     value INTEGER NOT NULL
-);
+) WITHOUT ROWID;
 INSERT INTO metadata_integer (key, value) VALUES ('version', 1);
 
 CREATE TABLE snapshots (
@@ -22,10 +22,10 @@ CREATE TABLE entries (
     path_id INTEGER NOT NULL,
     size INTEGER NOT NULL,
     is_dir INTEGER NOT NULL,
-    PRIMARY KEY (snapshot_id, path_id)
-);
-CREATE INDEX entries_path_id ON entries (path_id);
+    PRIMARY KEY (path_id, snapshot_id)
+) WITHOUT ROWID;
+CREATE INDEX entries_snapshot_id ON entries (snapshot_id); -- for deletion
 
 CREATE TABLE marks (
     path TEXT PRIMARY KEY
-);
+) WITHOUT ROWID;

--- a/src/cache/sql/v0_to_v1.sql
+++ b/src/cache/sql/v0_to_v1.sql
@@ -10,12 +10,6 @@ CREATE TABLE metadata_integer (
 ) WITHOUT ROWID;
 INSERT INTO metadata_integer (key, value) VALUES ('version', 1);
 
-CREATE TABLE snapshots (
-    id INTEGER PRIMARY KEY,
-    hash TEXT UNIQUE NOT NULL
-);
-CREATE INDEX snapshots_hash ON snapshots (hash);
-
 CREATE TABLE paths (
     id INTEGER PRIMARY KEY,
     parent_id INTEGER NOT NULL,
@@ -23,23 +17,9 @@ CREATE TABLE paths (
 );
 CREATE UNIQUE INDEX paths_parent_component ON paths (parent_id, component);
 
-CREATE TABLE entries (
-    snapshot_id INTEGER NOT NULL,
-    path_id INTEGER NOT NULL,
-    size INTEGER NOT NULL,
-    is_dir INTEGER NOT NULL,
-    PRIMARY KEY (path_id, snapshot_id)
-) WITHOUT ROWID;
-CREATE INDEX entries_snapshot_id ON entries (snapshot_id); -- for deletion
+-- The entries tables are sharded per snapshot and created dynamically
 
---------------------------------------------------------------------------------
-CREATE TABLE new_marks (
-    path TEXT PRIMARY KEY
-) WITHOUT ROWID;
-
-INSERT INTO new_marks (path)
-SELECT path FROM marks;
-
+CREATE TABLE new_marks (path TEXT PRIMARY KEY) WITHOUT ROWID;
+INSERT INTO new_marks (path) SELECT path FROM marks;
 DROP TABLE marks;
-
 ALTER TABLE new_marks RENAME TO marks;

--- a/src/cache/sql/v0_to_v1.sql
+++ b/src/cache/sql/v0_to_v1.sql
@@ -7,7 +7,7 @@ DROP TABLE directories;
 CREATE TABLE metadata_integer (
     key TEXT PRIMARY KEY,
     value INTEGER NOT NULL
-);
+) WITHOUT ROWID;
 INSERT INTO metadata_integer (key, value) VALUES ('version', 1);
 
 CREATE TABLE snapshots (
@@ -28,6 +28,18 @@ CREATE TABLE entries (
     path_id INTEGER NOT NULL,
     size INTEGER NOT NULL,
     is_dir INTEGER NOT NULL,
-    PRIMARY KEY (snapshot_id, path_id)
-);
-CREATE INDEX entries_path_id ON entries (path_id);
+    PRIMARY KEY (path_id, snapshot_id)
+) WITHOUT ROWID;
+CREATE INDEX entries_snapshot_id ON entries (snapshot_id); -- for deletion
+
+--------------------------------------------------------------------------------
+CREATE TABLE new_marks (
+    path TEXT PRIMARY KEY
+) WITHOUT ROWID;
+
+INSERT INTO new_marks (path)
+SELECT path FROM marks;
+
+DROP TABLE marks;
+
+ALTER TABLE new_marks RENAME TO marks;

--- a/src/cache/tests.rs
+++ b/src/cache/tests.rs
@@ -386,11 +386,7 @@ fn test_migrate_v0_to_v1() {
     let cache =
         Migrator::open_with_target(&file, 1).unwrap().migrate().unwrap();
 
-    assert_tables(&cache.conn, &[
-        "metadata_integer",
-        "paths",
-        "marks",
-    ]);
+    assert_tables(&cache.conn, &["metadata_integer", "paths", "marks"]);
 
     assert_marks(&cache, &marks);
 

--- a/src/cache/tests.rs
+++ b/src/cache/tests.rs
@@ -254,7 +254,7 @@ fn cache_snapshots_entries() {
             let mut db_snapshots = cache.get_snapshots().unwrap();
             db_snapshots.sort();
             let mut hashes =
-                hashes.into_iter().map(Box::from).collect::<Vec<Box<str>>>();
+                hashes.into_iter().map(String::from).collect::<Vec<String>>();
             hashes.sort();
             assert_eq!(db_snapshots, hashes);
         }
@@ -388,9 +388,7 @@ fn test_migrate_v0_to_v1() {
 
     assert_tables(&cache.conn, &[
         "metadata_integer",
-        "snapshots",
         "paths",
-        "entries",
         "marks",
     ]);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -270,14 +270,14 @@ fn sync_snapshots(
     fetching_thread_count: usize,
 ) -> anyhow::Result<()> {
     // Figure out what snapshots we need to fetch
-    let missing_snapshots: Vec<Box<str>> = {
+    let missing_snapshots: Vec<String> = {
         // Fetch snapshot list
         let pb = new_pb(" {spinner} Fetching repository snapshot list");
         let repo_snapshots = restic
             .snapshots()?
             .into_iter()
             .map(|s| s.id)
-            .collect::<Vec<Box<str>>>();
+            .collect::<Vec<String>>();
         pb.finish();
 
         // Delete snapshots from the DB that were deleted on the repo
@@ -285,7 +285,7 @@ fn sync_snapshots(
             .get_snapshots()?
             .into_iter()
             .filter(|snapshot| !repo_snapshots.contains(snapshot))
-            .collect::<Vec<Box<str>>>();
+            .collect::<Vec<String>>();
         if !snapshots_to_delete.is_empty() {
             eprintln!(
                 "Need to delete {} snapshot(s)",
@@ -344,7 +344,7 @@ fn sync_snapshots(
 
         // Channel to funnel snapshots from the fetching threads to the db thread
         let (snapshot_sender, snapshot_receiver) =
-            mpsc::sync_channel::<(Box<str>, SizeTree)>(fetching_thread_count);
+            mpsc::sync_channel::<(String, SizeTree)>(fetching_thread_count);
 
         // Start fetching threads
         for i in 0..fetching_thread_count {
@@ -402,9 +402,9 @@ enum FetchingThreadError {
 
 fn fetching_thread_body(
     restic: &Restic,
-    missing_queue: FixedSizeQueue<Box<str>>,
+    missing_queue: FixedSizeQueue<String>,
     mpb: MultiProgress,
-    snapshot_sender: mpsc::SyncSender<(Box<str>, SizeTree)>,
+    snapshot_sender: mpsc::SyncSender<(String, SizeTree)>,
     should_quit: Arc<AtomicBool>,
 ) -> Result<(), FetchingThreadError> {
     defer! { trace!("terminated") }
@@ -464,7 +464,7 @@ fn db_thread_body(
     cache: &mut Cache,
     mpb: MultiProgress,
     main_pb: ProgressBar,
-    snapshot_receiver: mpsc::Receiver<(Box<str>, SizeTree)>,
+    snapshot_receiver: mpsc::Receiver<(String, SizeTree)>,
     should_quit: Arc<AtomicBool>,
     should_quit_poll_period: Duration,
 ) -> Result<(), DBThreadError> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -495,13 +495,14 @@ fn db_thread_body(
                 )
                 .with_prefix(short_id.clone());
                 let start = Instant::now();
-                cache.save_snapshot(id, sizetree)?;
+                let file_count = cache.save_snapshot(id, sizetree)?;
                 pb.finish_and_clear();
                 mpb.remove(&pb);
                 main_pb.inc(1);
                 info!(
-                    "waited {}s to save snapshot",
-                    start.elapsed().as_secs_f64()
+                    "waited {}s to save snapshot ({} files)",
+                    start.elapsed().as_secs_f64(),
+                    file_count
                 );
                 trace!("snapshot saved");
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -317,7 +317,7 @@ fn sync_snapshots(
         n => n,
     };
 
-    let missing_queue = Queue::new(missing_snapshots);
+    let missing_queue = FixedSizeQueue::new(missing_snapshots);
 
     // Create progress indicators
     let mpb = MultiProgress::new();
@@ -402,7 +402,7 @@ enum FetchingThreadError {
 
 fn fetching_thread_body(
     restic: &Restic,
-    missing_queue: Queue<Box<str>>,
+    missing_queue: FixedSizeQueue<Box<str>>,
     mpb: MultiProgress,
     snapshot_sender: mpsc::SyncSender<(Box<str>, SizeTree)>,
     should_quit: Arc<AtomicBool>,
@@ -616,11 +616,11 @@ fn snapshot_short_id(id: &str) -> String {
 }
 
 #[derive(Clone)]
-struct Queue<T>(Arc<Mutex<Vec<T>>>);
+struct FixedSizeQueue<T>(Arc<Mutex<Vec<T>>>);
 
-impl<T> Queue<T> {
+impl<T> FixedSizeQueue<T> {
     fn new(data: Vec<T>) -> Self {
-        Queue(Arc::new(Mutex::new(data)))
+        FixedSizeQueue(Arc::new(Mutex::new(data)))
     }
 
     fn pop(&self) -> Option<T> {

--- a/src/restic.rs
+++ b/src/restic.rs
@@ -269,7 +269,7 @@ impl<T: DeserializeOwned> Iterator for Iter<T> {
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct Snapshot {
-    pub id: Box<str>,
+    pub id: String,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION
The entries table was causing insertion slowdowns as it grew, and deleting snapshots was rather slow.

With the sharded entries it's faster to save and delete snapshots.