### PR TITLE
Gracefully handle the case where the repository has no snapshots

### DIFF
--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -149,6 +149,9 @@ impl Cache {
             })
             .intersperse(String::from(" UNION ALL "))
             .collect::<String>();
+        if cte_stmt_string.is_empty() {
+            return Ok(vec![]);
+        }
         let mut stmt = self.conn.prepare(&format!(
             "WITH rich_entries AS ({cte_stmt_string}) \
              SELECT \

--- a/src/main.rs
+++ b/src/main.rs
@@ -177,6 +177,12 @@ fn main() -> anyhow::Result<()> {
 
     sync_snapshots(&restic, &mut cache, cli.fetching_thread_count)?;
 
+    let entries = cache.get_entries(None)?;
+    if entries.is_empty() {
+        eprintln!("The repository has no snapshots!");
+        return Ok(());
+    }
+
     // UI
     stderr().execute(EnterAlternateScreen)?;
     panic::update_hook(|prev, info| {
@@ -197,7 +203,7 @@ fn main() -> anyhow::Result<()> {
             rect.as_size(),
             None,
             Utf8PathBuf::new(),
-            cache.get_entries(None)?,
+            entries,
             cache.get_marks().unwrap(),
             vec![
                 "Enter".bold(),
@@ -310,6 +316,7 @@ fn sync_snapshots(
         })
         .collect();
     missing_snapshots.shuffle(&mut thread_rng());
+    missing_snapshots = vec![];
     let total_missing_snapshots = match missing_snapshots.len() {
         0 => {
             eprintln!("Snapshots up to date");


### PR DESCRIPTION
This makes redu show a message when the repository has no snapshots rather than crashing with a SQL error.