### PR TITLE
Do not show size bars when the terminal is below a certain width

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -316,7 +316,6 @@ fn sync_snapshots(
         })
         .collect();
     missing_snapshots.shuffle(&mut thread_rng());
-    missing_snapshots = vec![];
     let total_missing_snapshots = match missing_snapshots.len() {
         0 => {
             eprintln!("Snapshots up to date");


### PR DESCRIPTION
If redu is run on a terminal that is fairly narrow we skip rendering the size bars to have more space for the file names.

Closes #26 