### PR TITLE
Add support for repository and password files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ description = "This is like ncdu for a restic repository."
 anyhow = "1"
 camino = "1"
 chrono = { version = "0.4", features = ["serde"] }
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 crossterm = "0.27"
 directories = "5"
 flexi_logger = "0.28"

--- a/README.md
+++ b/README.md
@@ -30,20 +30,23 @@ Note: it currently requires nightly to build.
  
 # Running
  
-You can use all the regular restic environment variables, they will be passed
-to all restic subprocesses redu spawns.
+You can specify the repository and the password command in exactly the same ways
+that restic supports, with the exception that redu will not prompt you for the password.
 
-For example:
+For example using environment variables:
 ```
 $ export RESTIC_REPOSITORY='sftp://my-backup-server.my-domain.net'
 $ export RESTIC_PASSWORD_COMMAND='security find-generic-password -s restic -a personal -w'
 $ redu 
 ```
 
-Alternatively, you can pass the repo and the password as arguments to redu:
+Or via command line arguments:
 ```
 redu -r 'sftp://my-backup-server.my-domain.net' --password-command 'security find-generic-password -s restic -a personal -w' 
 ```
+
+Note: `--repository-file` (env: `RESTIC_REPOSITORY_FILE`) and `--password-file` (env: `RESTIC_PASSWORD_FILE`)
+are supported as well and work just like in restic.
 
 # Usage
 Redu keeps a cache with your file/directory sizes (per repo).

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ about the currently highlighted item:
 You can keep navigating with the details window open and it will update as you
 browse around.
 
+Hint: you can press **Escape** to close the details window (as well as other dialogs).
+
 ### Marking files 
 You can mark files and directories to build up your list of things to exclude.
 Keybinds

--- a/src/args.rs
+++ b/src/args.rs
@@ -67,6 +67,8 @@ impl Args {
 /// Keybinds:
 /// Arrows or hjkl: Movement
 /// PgUp/PgDown or C-b/C-f: Page up / Page down
+/// Enter: Details
+/// Escape: Close dialog
 /// m: Mark
 /// u: Unmark
 /// c: Clear all marks

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,0 +1,101 @@
+use clap::{ArgGroup, Parser};
+use log::LevelFilter;
+
+use crate::restic::Password;
+
+#[derive(Debug)]
+pub struct Args {
+    pub repo: Option<String>,
+    pub password: Password,
+    pub parallelism: usize,
+    pub log_level: LevelFilter,
+    pub no_cache: bool,
+}
+
+impl Args {
+    /// Parse arguments from std::env::args_os(), exit on error.
+    pub fn parse() -> Self {
+        let cli = Cli::parse();
+
+        Args {
+            repo: cli.repo,
+            password: if let Some(command) = cli.password_command {
+                Password::Command(command)
+            } else if let Some(file) = cli.password_file {
+                Password::File(file)
+            } else {
+                unreachable!("Error in Config: neither password_command nor password_file found. Please open an issue if you see this.")
+            },
+            parallelism: cli.parallelism,
+            log_level: match cli.verbose {
+                0 => LevelFilter::Info,
+                1 => LevelFilter::Debug,
+                _ => LevelFilter::Trace,
+            },
+            no_cache: cli.no_cache,
+        }
+    }
+}
+
+/// This is like ncdu for a restic respository.
+///
+/// It computes the size for each directory/file by
+/// taking the largest over all snapshots in the repository.
+///
+/// You can browse your repository and mark directories/files.
+/// These marks are persisted across runs of redu.
+///
+/// When you're happy with the marks you can generate
+/// a list to stdout with everything that you marked.
+///   This list can be used directly as an exclude-file for restic.
+///
+/// Redu keeps all messages and UI in stderr,
+/// only the marks list is generated to stdout.
+///   This means that you can pipe redu directly to a file
+/// to get the exclude-file.
+///
+/// NOTE: redu will never do any kind of modification to your repo.
+/// It's strictly read-only.
+///
+/// Keybinds:
+/// Arrows or hjkl: Movement
+/// PgUp/PgDown or C-b/C-f: Page up / Page down
+/// m: Mark
+/// u: Unmark
+/// c: Clear all marks
+/// g: Generate
+/// q: Quit
+#[derive(Parser)]
+#[command(version, long_about, verbatim_doc_comment)]
+#[command(group(
+    ArgGroup::new("password")
+        .required(true)
+        .args(["password_command", "password_file"]),
+))]
+struct Cli {
+    #[arg(short = 'r', long)]
+    repo: Option<String>,
+
+    #[arg(long, value_name = "COMMAND", env = "RESTIC_PASSWORD_COMMAND")]
+    password_command: Option<String>,
+
+    #[arg(long, value_name = "FILE", env = "RESTIC_PASSWORD_FILE")]
+    password_file: Option<String>,
+
+    ///  How many restic subprocesses to spawn concurrently.
+    ///
+    /// If you get ssh-related errors or too much memory use try lowering this.
+    #[arg(short = 'j', value_name = "NUMBER", default_value_t = 4)]
+    parallelism: usize,
+
+    /// Log verbosity level. You can pass it multiple times (maxes out at two).
+    #[arg(
+        short = 'v',
+        action = clap::ArgAction::Count,
+    )]
+    verbose: u8,
+
+    /// Pass the --no-cache option to restic subprocesses.
+    #[arg(long)]
+    no_cache: bool,
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,7 @@ mod util;
 
 fn main() -> anyhow::Result<()> {
     let args = Args::parse();
-    let restic = Restic::new(args.repo, args.password, args.no_cache);
+    let restic = Restic::new(args.repository, args.password, args.no_cache);
 
     let dirs = ProjectDirs::from("eu", "drdo", "redu")
         .expect("unable to determine project directory");

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,7 +83,7 @@ struct Cli {
     #[arg(short = 'r', long)]
     repo: Option<String>,
 
-    #[arg(long)]
+    #[arg(long, value_name = "COMMAND")]
     password_command: Option<String>,
 
     ///  How many restic subprocesses to spawn concurrently.

--- a/src/restic.rs
+++ b/src/restic.rs
@@ -95,9 +95,17 @@ pub struct Config {
 }
 
 pub struct Restic {
-    repo: Option<String>,
+    repository: Repository,
     password: Password,
     no_cache: bool,
+}
+
+#[derive(Debug)]
+pub enum Repository {
+    /// A repository string (restic: --repo)
+    Repo(String),
+    /// A repository file (restic: --repository-file)
+    File(String),
 }
 
 #[derive(Debug)]
@@ -110,11 +118,11 @@ pub enum Password {
 
 impl Restic {
     pub fn new(
-        repo: Option<String>,
+        repository: Repository,
         password: Password,
         no_cache: bool,
     ) -> Self {
-        Restic { repo, password, no_cache }
+        Restic { repository, password, no_cache }
     }
 
     pub fn config(&self) -> Result<Config, Error> {
@@ -200,9 +208,10 @@ impl Restic {
                 Ok(())
             });
         }
-        if let Some(repo) = &self.repo {
-            cmd.arg("--repo").arg(repo);
-        }
+        match &self.repository {
+            Repository::Repo(repo) => cmd.arg("--repo").arg(repo),
+            Repository::File(file) => cmd.arg("--repository-file").arg(file),
+        };
         match &self.password {
             Password::Command(command) =>
                 cmd.arg("--password-command").arg(command),

--- a/src/restic.rs
+++ b/src/restic.rs
@@ -96,17 +96,25 @@ pub struct Config {
 
 pub struct Restic {
     repo: Option<String>,
-    password_command: Option<String>,
+    password: Password,
     no_cache: bool,
+}
+
+#[derive(Debug)]
+pub enum Password {
+    /// A password command (restic: --password-command)
+    Command(String),
+    /// A password file (restic: --password-file)
+    File(String),
 }
 
 impl Restic {
     pub fn new(
         repo: Option<String>,
-        password_command: Option<String>,
+        password: Password,
         no_cache: bool,
     ) -> Self {
-        Restic { repo, password_command, no_cache }
+        Restic { repo, password, no_cache }
     }
 
     pub fn config(&self) -> Result<Config, Error> {
@@ -195,9 +203,11 @@ impl Restic {
         if let Some(repo) = &self.repo {
             cmd.arg("--repo").arg(repo);
         }
-        if let Some(password_command) = &self.password_command {
-            cmd.arg("--password-command").arg(password_command);
-        }
+        match &self.password {
+            Password::Command(command) =>
+                cmd.arg("--password-command").arg(command),
+            Password::File(file) => cmd.arg("--password-file").arg(file),
+        };
         if self.no_cache {
             cmd.arg("--no-cache");
         }


### PR DESCRIPTION
* Adds support for `--repository-file` and `--password-file`.
* We now read the restic repository and password-command environment variables instead of them being implicitly passed to restic.
* The help now explicitly shows the repository/password-command environment variables
* Some README updates