### PR TITLE
Fix non-working 'l' vim keybind to enter a directory

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2024-07-28"

--- a/src/main.rs
+++ b/src/main.rs
@@ -473,7 +473,7 @@ fn convert_event(event: crossterm::event::Event) -> Option<Event> {
         ((KeyModifiers::empty(), KeyCode::Left), Left),
         ((KeyModifiers::empty(), KeyCode::Char('h')), Left),
         ((KeyModifiers::empty(), KeyCode::Right), Right),
-        ((KeyModifiers::empty(), KeyCode::Char(';')), Right),
+        ((KeyModifiers::empty(), KeyCode::Char('l')), Right),
         ((KeyModifiers::empty(), KeyCode::Up), Up),
         ((KeyModifiers::empty(), KeyCode::Char('k')), Up),
         ((KeyModifiers::empty(), KeyCode::Down), Down),


### PR DESCRIPTION
Additionally temporarily fixes the version of nightly due to rust-lang/rust#128401

Closes #52 