### PR TITLE
add support for RESTIC_PASSWORD env variable

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -30,6 +30,8 @@ impl Args {
                 Password::Command(command)
             } else if let Some(file) = cli.password_file {
                 Password::File(file)
+            } else if let Some(str) = cli.restic_password {
+                Password::Plain(str)
             } else {
                 unreachable!("Error in Config: neither password_command nor password_file found. Please open an issue if you see this.")
             },
@@ -84,7 +86,7 @@ impl Args {
 #[command(group(
     ArgGroup::new("password")
         .required(true)
-        .args(["password_command", "password_file"]),
+        .args(["password_command", "password_file", "restic_password"]),
 ))]
 struct Cli {
     #[arg(short = 'r', long, env = "RESTIC_REPOSITORY")]
@@ -98,6 +100,9 @@ struct Cli {
 
     #[arg(long, value_name = "FILE", env = "RESTIC_PASSWORD_FILE")]
     password_file: Option<String>,
+
+    #[arg(value_name = "RESTIC_PASSWORD", env = "RESTIC_PASSWORD")]
+    restic_password: Option<String>,
 
     ///  How many restic subprocesses to spawn concurrently.
     ///

--- a/src/restic.rs
+++ b/src/restic.rs
@@ -110,6 +110,8 @@ pub enum Repository {
 
 #[derive(Debug)]
 pub enum Password {
+    /// A plain string (restic: RESTIC_PASSWORD env variable)
+    Plain(String),
     /// A password command (restic: --password-command)
     Command(String),
     /// A password file (restic: --password-file)
@@ -216,6 +218,8 @@ impl Restic {
             Password::Command(command) =>
                 cmd.arg("--password-command").arg(command),
             Password::File(file) => cmd.arg("--password-file").arg(file),
+            // Nothing to do, the password is given as an env variable already.
+            Password::Plain(_str) => &cmd,
         };
         if self.no_cache {
             cmd.arg("--no-cache");


### PR DESCRIPTION
The restic tool doesn't have a CLI parameter for this, but it allows setting an env variable. We can check for that too and keep this as an env variable only.

This way we keep the safety of knowing that all necessary parameters (i.e. the repo and password options) are set.

This fixes #55 .