### PR TITLE
prompt for password if none is given

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -948,6 +948,7 @@ dependencies = [
  "nix",
  "rand",
  "ratatui",
+ "rpassword",
  "rusqlite",
  "scopeguard",
  "serde",
@@ -985,6 +986,27 @@ name = "regex-syntax"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+
+[[package]]
+name = "rpassword"
+version = "7.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80472be3c897911d0137b2d2b9055faf6eeac5b14e324073d83bc17b191d7e3f"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c247d24e63230cdb56463ae328478bd5eac8b8faa8c69461a77e8e323afac90e"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "rusqlite"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ ratatui = { version = "0.27", features = [
         "unstable-rendered-line-info",
         "unstable-widget-ref",
 ] }
+rpassword = "7.3.1"
 rusqlite = { version = "0.32", features = ["bundled", "functions", "trace"] }
 scopeguard = "1"
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Note: it currently requires nightly to build.
 # Running
  
 You can specify the repository and the password command in exactly the same ways
-that restic supports, with the exception that redu will not prompt you for the password.
+that restic supports.
 
 For example using environment variables:
 ```
@@ -48,6 +48,9 @@ redu -r 'sftp://my-backup-server.my-domain.net' --password-command 'security fin
 Note: `--repository-file` (env: `RESTIC_REPOSITORY_FILE`) and `--password-file` (env: `RESTIC_PASSWORD_FILE`),
 as well as plain text passwords set via the `RESTIC_PASSWORD` environment variable,
 are supported as well and work just like in restic.
+
+Similar to restic, redu will prompt you to enter the password, if it isn't
+given any other way.
 
 # Usage
 Redu keeps a cache with your file/directory sizes (per repo).

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,6 +1,7 @@
 use clap::{ArgGroup, Parser};
 use log::LevelFilter;
 use redu::restic::Repository;
+use rpassword::read_password;
 
 use crate::restic::Password;
 
@@ -33,7 +34,7 @@ impl Args {
             } else if let Some(str) = cli.restic_password {
                 Password::Plain(str)
             } else {
-                unreachable!("Error in Config: neither password_command nor password_file found. Please open an issue if you see this.")
+                Password::Plain(Self::read_password_from_stdin())
             },
             parallelism: cli.parallelism,
             log_level: match cli.verbose {
@@ -43,6 +44,11 @@ impl Args {
             },
             no_cache: cli.no_cache,
         }
+    }
+
+    fn read_password_from_stdin() -> String {
+        eprint!("enter password for repository: ");
+        read_password().unwrap()
     }
 }
 
@@ -82,11 +88,6 @@ impl Args {
     ArgGroup::new("repository")
         .required(true)
         .args(["repo", "repository_file"]),
-))]
-#[command(group(
-    ArgGroup::new("password")
-        .required(true)
-        .args(["password_command", "password_file", "restic_password"]),
 ))]
 struct Cli {
     #[arg(short = 'r', long, env = "RESTIC_REPOSITORY")]

--- a/src/restic.rs
+++ b/src/restic.rs
@@ -218,8 +218,9 @@ impl Restic {
             Password::Command(command) =>
                 cmd.arg("--password-command").arg(command),
             Password::File(file) => cmd.arg("--password-file").arg(file),
-            // Nothing to do, the password is given as an env variable already.
-            Password::Plain(_str) => &cmd,
+            // There's no way to hand over the password to restic directly, so we use the env
+            // variable instead.
+            Password::Plain(str) => cmd.env("RESTIC_PASSWORD", str),
         };
         if self.no_cache {
             cmd.arg("--no-cache");


### PR DESCRIPTION
This shows a password prompt, if neither the `--password-file` or `--password-command` option is given **and** the `RESTIC_PASSWORD` env variable is unset.

There's no way to hand over the password to restic as a CLI parameter, so we use the `RESTIC_PASSWORD` env variable under the hood to set it instead. The env variable is only valid for the restic process we call internally, so the next time redu is run, it'll prompt for the password again.

This fixes #27 .