### PR TITLE
Add support for more than 500 snapshots in a repository

### DIFF
--- a/benches/cache.rs
+++ b/benches/cache.rs
@@ -1,7 +1,10 @@
 use std::cell::Cell;
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use redu::{cache::tests::*, restic::Snapshot};
+use redu::{
+    cache::{tests::*, Migrator},
+    restic::Snapshot,
+};
 
 pub fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("merge sizetree", |b| {
@@ -12,10 +15,47 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         b.iter(move || sizetree0.take().merge(black_box(sizetree1.take())));
     });
 
-    c.bench_function("create and save snapshot", |b| {
-        with_cache_open(|mut cache| {
-            let foo = Snapshot {
-                id: "foo".to_string(),
+    c.bench_function("save snapshot", |b| {
+        let foo = Snapshot {
+            id: "foo".to_string(),
+            time: mk_datetime(2024, 4, 12, 12, 00, 00),
+            parent: Some("bar".to_string()),
+            tree: "sometree".to_string(),
+            paths: vec![
+                "/home/user".to_string(),
+                "/etc".to_string(),
+                "/var".to_string(),
+            ],
+            hostname: Some("foo.com".to_string()),
+            username: Some("user".to_string()),
+            uid: Some(123),
+            gid: Some(456),
+            excludes: vec![
+                ".cache".to_string(),
+                "Cache".to_string(),
+                "/home/user/Downloads".to_string(),
+            ],
+            tags: vec!["foo_machine".to_string(), "rewrite".to_string()],
+            original_id: Some("fefwfwew".to_string()),
+            program_version: Some("restic 0.16.0".to_string()),
+        };
+        b.iter_with_setup(
+            || {
+                let tempfile = Tempfile::new();
+                let cache =
+                    Migrator::open(&tempfile.0).unwrap().migrate().unwrap();
+                (tempfile, cache, generate_sizetree(6, 12))
+            },
+            |(_tempfile, mut cache, tree)| {
+                cache.save_snapshot(&foo, tree).unwrap()
+            },
+        );
+    });
+
+    c.bench_function("save lots of small snapshots", |b| {
+        fn mk_snapshot(id: String) -> Snapshot {
+            Snapshot {
+                id,
                 time: mk_datetime(2024, 4, 12, 12, 00, 00),
                 parent: Some("bar".to_string()),
                 tree: "sometree".to_string(),
@@ -36,16 +76,27 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                 tags: vec!["foo_machine".to_string(), "rewrite".to_string()],
                 original_id: Some("fefwfwew".to_string()),
                 program_version: Some("restic 0.16.0".to_string()),
-            };
-            b.iter(move || {
-                cache
-                    .save_snapshot(
-                        &foo,
-                        generate_sizetree(black_box(6), black_box(12)),
-                    )
-                    .unwrap();
-            });
-        })
+            }
+        }
+
+        b.iter_with_setup(
+            || {
+                let tempfile = Tempfile::new();
+                let cache =
+                    Migrator::open(&tempfile.0).unwrap().migrate().unwrap();
+                (tempfile, cache, generate_sizetree(1, 0))
+            },
+            |(_tempfile, mut cache, tree)| {
+                for i in 0..10_000 {
+                    cache
+                        .save_snapshot(
+                            &mk_snapshot(i.to_string()),
+                            tree.clone(),
+                        )
+                        .unwrap();
+                }
+            },
+        );
     });
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -191,7 +191,8 @@ fn main() -> anyhow::Result<()> {
                     Some(Event::Entries { path_id, entries })
                 }
                 Action::GetEntryDetails(path_id) =>
-                    Some(Event::EntryDetails(cache.get_entry_details(path_id)?)),
+                    Some(Event::EntryDetails(cache.get_entry_details(path_id)?
+                        .expect("The UI requested a GetEntryDetails with a path_id that does not exist"))),
                 Action::UpsertMark(path) => {
                     cache.upsert_mark(&path)?;
                     Some(Event::Marks(cache.get_marks()?))


### PR DESCRIPTION
Due to a limitation of sqlite we previously only supported at most 500 snapshots and having more snapshots in a repository would result in a crash.

Fixes #62 