### PR TITLE
Use defer! rather than panic hooks for terminal restoration

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,6 @@
-#![feature(panic_update_hook)]
-
 use std::{
     fs,
     io::stderr,
-    panic,
     sync::{
         atomic::{AtomicBool, Ordering},
         mpsc::{self, RecvTimeoutError},
@@ -126,15 +123,13 @@ fn main() -> anyhow::Result<()> {
 
     // UI
     stderr().execute(EnterAlternateScreen)?;
-    panic::update_hook(|prev, info| {
+    defer! {
         stderr().execute(LeaveAlternateScreen).unwrap();
-        prev(info);
-    });
+    }
     enable_raw_mode()?;
-    panic::update_hook(|prev, info| {
+    defer! {
         disable_raw_mode().unwrap();
-        prev(info);
-    });
+    }
     let mut terminal = Terminal::new(CrosstermBackend::new(stderr()))?;
     terminal.clear()?;
 
@@ -208,9 +203,6 @@ fn main() -> anyhow::Result<()> {
             }
         }
     }
-
-    disable_raw_mode()?;
-    stderr().execute(LeaveAlternateScreen)?;
 
     for line in output_paths {
         println!("{}", escape_for_exclude(line.as_str()));


### PR DESCRIPTION
This handles all of the possible ways we could possibly exit including through early returns and usage of ?.

Previously the terminal state would not be restored in some situations where we exit via ? (for example when there is an error in `sync_snapshots`).