### PR TITLE
Remove specific nightly version

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2024-07-28"
+channel = "nightly"


### PR DESCRIPTION
The rustc [issue](https://github.com/rust-lang/rust/issues/128401) should be fixed now.