### PR TITLE
Fix Windows bug where we were using log file names with colons

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,7 @@ fn main() -> anyhow::Result<()> {
     // Initialize the logger
     {
         fn generate_filename() -> String {
-            format!("{}.log", Local::now().format("%Y-%m-%dT%H:%M:%S%.f%:z"))
+            format!("{}.log", Local::now().format("%Y-%m-%dT%H-%M-%S%.f%z"))
         }
 
         let mut path = dirs.data_local_dir().to_path_buf();


### PR DESCRIPTION
Fixes #86 