### PR TITLE
Update dependencies and fix warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ crossterm = "0.29"
 directories = "6"
 simplelog = "0.12"
 humansize = "2"
-indicatif = "0.17"
+indicatif = "0.18"
 log = "0.4"
 rand = "0.9"
 ratatui = { version = "0.29", features = [
@@ -27,7 +27,7 @@ ratatui = { version = "0.29", features = [
     "unstable-widget-ref",
 ] }
 rpassword = "7.3.1"
-rusqlite = { version = "0.35", features = ["bundled", "functions", "trace"] }
+rusqlite = { version = "0.37", features = ["bundled", "functions", "trace"] }
 scopeguard = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -36,7 +36,7 @@ unicode-segmentation = "1"
 uuid = { version = "1", features = ["v4"], optional = true }
 
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.29", features = ["process"] }
+nix = { version = "0.30", features = ["process"] }
 
 [lib]
 path = "src/lib.rs"
@@ -53,7 +53,7 @@ codegen-units = 1
 lto = "fat"
 
 [dev-dependencies]
-criterion = { version = "0.5", features = ["html_reports"] }
+criterion = { version = "0.7", features = ["html_reports"] }
 uuid = { version = "1", features = ["v4"] }
 
 [[bench]]

--- a/src/restic.rs
+++ b/src/restic.rs
@@ -360,7 +360,7 @@ pub struct File {
     pub size: usize,
 }
 
-pub fn escape_for_exclude(path: &str) -> Cow<str> {
+pub fn escape_for_exclude(path: &str) -> Cow<'_, str> {
     fn is_special(c: char) -> bool {
         ['*', '?', '[', '\\', '\r', '\n'].contains(&c)
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -485,7 +485,7 @@ fn render_name(
     is_dir: bool,
     selected: bool,
     available_width: usize,
-) -> Span {
+) -> Span<'_> {
     let mut escaped = escape_name(name);
     if is_dir {
         if !escaped.ends_with('/') {
@@ -504,7 +504,7 @@ fn render_name(
     }
 }
 
-fn escape_name(name: &str) -> Cow<str> {
+fn escape_name(name: &str) -> Cow<'_, str> {
     match name.find(char::is_control) {
         None => Cow::Borrowed(name),
         Some(index) => {
@@ -525,7 +525,7 @@ fn escape_name(name: &str) -> Cow<str> {
     }
 }
 
-fn shorten_to(s: &str, width: usize) -> Cow<str> {
+fn shorten_to(s: &str, width: usize) -> Cow<'_, str> {
     let len = s.graphemes(true).count();
     let res = if len <= width {
         Cow::Borrowed(s)


### PR DESCRIPTION
No code change has been needed for the dependencies.

Since Rust 1.89.0, lifetimes should be elided explicitly using `'_` on the return type if it borrows from a parameter, so let’s do that.